### PR TITLE
Implement PathFormat.IsValidExtension API

### DIFF
--- a/Source/Singulink.IO.FileSystem/PathFormat.Universal.cs
+++ b/Source/Singulink.IO.FileSystem/PathFormat.Universal.cs
@@ -15,12 +15,12 @@ public abstract partial class PathFormat
 
         internal override PathKind GetPathKind(ReadOnlySpan<char> path) => PathKind.Relative;
 
-        internal override bool ValidateEntryName(ReadOnlySpan<char> name, PathOptions options, bool allowWildcards, [NotNullWhen(false)] out string? error)
+        internal override bool ValidateEntryName(ReadOnlySpan<char> name, PathOptions options, bool allowWildcards, [NotNullWhen(false)] out string? error, bool wantsError = true)
         {
-            if (!Unix.ValidateEntryName(name, options, allowWildcards, out error))
+            if (!Unix.ValidateEntryName(name, options, allowWildcards, out error, wantsError))
                 return false;
 
-            if (!Windows.ValidateEntryName(name, options, allowWildcards, out error))
+            if (!Windows.ValidateEntryName(name, options, allowWildcards, out error, wantsError))
                 return false;
 
             error = null;

--- a/Source/Singulink.IO.FileSystem/PathFormat.Windows.cs
+++ b/Source/Singulink.IO.FileSystem/PathFormat.Windows.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using Singulink.Enums;
@@ -11,8 +12,8 @@ public abstract partial class PathFormat
 {
     private sealed class WindowsPathFormat : PathFormat
     {
-        private static readonly FrozenSet<char> InvalidNameChars = GetInvalidNameChars(true);
-        private static readonly FrozenSet<char> InvalidNameCharsWithoutWildcards = GetInvalidNameChars(false);
+        private static readonly SearchValues<char> InvalidNameChars = GetInvalidNameChars(true);
+        private static readonly SearchValues<char> InvalidNameCharsWithoutWildcards = GetInvalidNameChars(false);
 
         internal WindowsPathFormat() : base('\\') { }
 
@@ -49,7 +50,7 @@ public abstract partial class PathFormat
             return path.Length > 0 && path[0] == Separator ? PathKind.RelativeRooted : PathKind.Relative;
         }
 
-        internal override bool ValidateEntryName(ReadOnlySpan<char> name, PathOptions options, bool allowWildcards, [NotNullWhen(false)] out string? error)
+        internal override bool ValidateEntryName(ReadOnlySpan<char> name, PathOptions options, bool allowWildcards, [NotNullWhen(false)] out string? error, bool wantsError = true)
         {
             options = options.SetFlags(PathOptions.NoControlCharacters);
 
@@ -61,24 +62,20 @@ public abstract partial class PathFormat
 
             if (allowWildcards)
             {
-                foreach (char c in name)
+                int idx = name.IndexOfAny(InvalidNameCharsWithoutWildcards);
+                if (idx >= 0)
                 {
-                    if (InvalidNameCharsWithoutWildcards.Contains(c))
-                    {
-                        error = $"Invalid character '{c}' in entry name '{name}'. Invalid characters include: < > : \" | / \\";
-                        return false;
-                    }
+                    error = wantsError ? $"Invalid character '{name[idx]}' in entry name '{name}'. Invalid characters include: < > : \" | / \\" : "invalid";
+                    return false;
                 }
             }
             else
             {
-                foreach (char c in name)
+                int idx = name.IndexOfAny(InvalidNameChars);
+                if (idx >= 0)
                 {
-                    if (InvalidNameChars.Contains(c))
-                    {
-                        error = $"Invalid character '{c}' in entry name '{name}'. Invalid characters include: < > : \" | ? * / \\";
-                        return false;
-                    }
+                    error = wantsError ? $"Invalid character '{name[idx]}' in entry name '{name}'. Invalid characters include: < > : \" | ? * / \\" : "invalid";
+                    return false;
                 }
             }
 
@@ -95,9 +92,9 @@ public abstract partial class PathFormat
                 // CON, PRN, AUX, NUL, COM1 to COM9, LPT1 to LPT9
 
                 if ((name.Length == 3 && (name.Equals("CON", comp) || name.Equals("PRN", comp) || name.Equals("AUX", comp) || name.Equals("NUL", comp))) ||
-                    (name.Length == 4 && char.IsDigit(name[3]) && (name.StartsWith("COM", comp) || name.StartsWith("LPT", comp))))
+                    (name.Length == 4 && (name[3] is >= '1' and <= '9') && (name.StartsWith("COM", comp) || name.StartsWith("LPT", comp))))
                 {
-                    error = $"Invalid reserved device name in entry name '{name}'.";
+                    error = wantsError ? $"Invalid reserved device name in entry name '{name}'." : "Invalid.";
                     return false;
                 }
             }
@@ -200,7 +197,7 @@ public abstract partial class PathFormat
         internal override string GetAbsolutePathExportString(string pathDisplay) =>
             pathDisplay[1] == ':' ? @"\\?\" + pathDisplay : $@"\\?\UNC\{pathDisplay.AsSpan()[2..]}";
 
-        private static FrozenSet<char> GetInvalidNameChars(bool includeWildcardChars)
+        private static SearchValues<char> GetInvalidNameChars(bool includeWildcardChars)
         {
             var invalidChars = new List<char>() { '<', '>', ':', '"', '|', '/', '\\' };
 
@@ -210,7 +207,7 @@ public abstract partial class PathFormat
                 invalidChars.Add('*');
             }
 
-            return invalidChars.ToFrozenSet();
+            return SearchValues.Create([.. invalidChars]);
         }
 
         public override string ToString() => "Windows";

--- a/Source/Singulink.IO.FileSystem/PathFormat.cs
+++ b/Source/Singulink.IO.FileSystem/PathFormat.cs
@@ -69,6 +69,26 @@ public abstract partial class PathFormat
     /// </summary>
     public abstract override string ToString();
 
+    /// <summary>
+    /// Determines whether the given file extension is valid for this path format.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The empty extension is valid for all path formats.</para>
+    /// <para>
+    /// If non-empty, the extension should begin with a <c>.</c> character, and not have any <c>.</c> characters after the first one.</para>
+    /// </remarks>
+    public virtual bool IsValidExtension(ReadOnlySpan<char> extension, PathOptions options = PathOptions.NoUnfriendlyNames)
+    {
+        if (extension is [])
+            return true;
+
+        if (extension is not ['.', .. var rest] || rest.Contains('.'))
+            return false;
+
+        return ValidateEntryName(extension, options & ~PathOptions.NoLeadingSpaces, allowWildcards: false, out _, wantsError: false);
+    }
+
     internal string ParentDirectoryWithSeparator { get; }
 
     internal PathFormat(char separator)
@@ -98,7 +118,8 @@ public abstract partial class PathFormat
 
     internal virtual ReadOnlySpan<char> NormalizeSeparators(ReadOnlySpan<char> path) => path;
 
-    internal virtual bool ValidateEntryName(ReadOnlySpan<char> name, PathOptions options, bool allowWildcards, [NotNullWhen(false)] out string? error)
+    // 'wantsError' indicates whether we should potentially allocate a useful error message or just return a possibly generic one or none.
+    internal virtual bool ValidateEntryName(ReadOnlySpan<char> name, PathOptions options, bool allowWildcards, [NotNullWhen(false)] out string? error, bool wantsError = true)
     {
         if (name.IsEmpty) {
             error = "Empty entry name.";
@@ -106,16 +127,15 @@ public abstract partial class PathFormat
         }
 
         if (name.IndexOfAny(Separator, (char)0) is int i and >= 0) {
-            error = $"Invalid character '{name[i]}' in entry name '{name}'.";
+            error = wantsError ? $"Invalid character '{name[i]}' in entry name '{name}'." : "Invalid.";
             return false;
         }
 
         if (options.HasAllFlags(PathOptions.NoControlCharacters)) {
-            foreach (char c in name) {
-                if (c < 32) {
-                    error = $"Invalid control character '{c}' in entry name '{name}'.";
-                    return false;
-                }
+            int idx = name.IndexOfAnyInRange((char)0, (char)31);
+            if (idx >= 0) {
+                error = wantsError ? $"Invalid control character '{name[idx]}' in entry name '{name}'." : "Invalid.";
+                return false;
             }
         }
 

--- a/Tests/Singulink.IO.FileSystem.Tests/RelativeDirectoryParseTests.cs
+++ b/Tests/Singulink.IO.FileSystem.Tests/RelativeDirectoryParseTests.cs
@@ -160,5 +160,8 @@ public class RelativeDirectoryParseTests
         Should.Throw<ArgumentException>(() => DirectoryPath.ParseRelative("/test/NUL", PathFormat.Windows, PathOptions.NoReservedDeviceNames));
         Should.Throw<ArgumentException>(() => DirectoryPath.ParseRelative("PRN/test", PathFormat.Windows, PathOptions.NoReservedDeviceNames));
         Should.Throw<ArgumentException>(() => DirectoryPath.ParseRelative("/test/LPT5/test2", PathFormat.Windows, PathOptions.NoReservedDeviceNames));
+
+        Should.NotThrow(() => DirectoryPath.ParseRelative("/COM0/", PathFormat.Windows, PathOptions.NoReservedDeviceNames));
+        Should.NotThrow(() => DirectoryPath.ParseRelative("/LPT0/", PathFormat.Windows, PathOptions.NoReservedDeviceNames));
     }
 }


### PR DESCRIPTION
- Implement PathFormat.IsValidExtension API (allocation free).
- Fix COM0/LPT0 bug (previously it was falsely flagged as problematic).
- Use vectorizable helpers in related code, rather than manual scalar loops.